### PR TITLE
Implements Freeze Functionality within the Veto Guard Contract

### DIFF
--- a/contracts/FractalBaseGuard.sol
+++ b/contracts/FractalBaseGuard.sol
@@ -1,0 +1,42 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
+import "@gnosis.pm/zodiac/contracts/interfaces/IGuard.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+abstract contract FractalBaseGuard is ERC165 {
+    /// @dev Module transactions only use the first four parameters: to, value, data, and operation.
+    /// Module.sol hardcodes the remaining parameters as 0 since they are not used for module transactions.
+    /// @notice This interface is used to maintain compatibilty with Gnosis Safe transaction guards.
+    function checkTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver,
+        bytes memory signatures,
+        address msgSender
+    ) external virtual;
+
+    function checkAfterExecution(bytes32 txHash, bool success) external virtual;
+
+    /// @notice Can be used to check if this contract supports the specified interface
+    /// @param interfaceId The bytes representing the interfaceId being checked
+    /// @return bool True if this contract supports the checked interface
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override
+        returns (bool)
+    {
+        return
+            interfaceId == type(IGuard).interfaceId || // 0xe6d7a83a
+            super.supportsInterface(interfaceId); // 0x01ffc9a7
+    }
+}

--- a/contracts/VetoERC20Voting.sol
+++ b/contracts/VetoERC20Voting.sol
@@ -10,7 +10,12 @@ import "@openzeppelin/contracts/governance/utils/IVotes.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @notice A contract for casting veto votes with an ERC20 votes token
-contract VetoERC20Voting is IVetoERC20Voting, TransactionHasher, Initializable, Ownable {
+contract VetoERC20Voting is
+    IVetoERC20Voting,
+    TransactionHasher,
+    Initializable,
+    Ownable
+{
     uint256 public vetoVotesThreshold; // Number of votes required to veto a transaction
     uint256 public freezeVotesThreshold; // Number of freeze votes required to activate a freeze
     uint256 public freezeProposalCreatedBlock; // Block number the freeze proposal was created at
@@ -104,6 +109,7 @@ contract VetoERC20Voting is IVetoERC20Voting, TransactionHasher, Initializable, 
                 msg.sender,
                 freezeProposalCreatedBlock - 1
             );
+            require(userVotes > 0, "User has no votes");
 
             freezeProposalVoteCount = userVotes;
 
@@ -119,6 +125,7 @@ contract VetoERC20Voting is IVetoERC20Voting, TransactionHasher, Initializable, 
                 msg.sender,
                 freezeProposalCreatedBlock - 1
             );
+            require(userVotes > 0, "User has no votes");
 
             freezeProposalVoteCount += userVotes;
         }
@@ -130,33 +137,44 @@ contract VetoERC20Voting is IVetoERC20Voting, TransactionHasher, Initializable, 
 
     /// @notice Unfreezes the DAO, only callable by the owner
     function defrost() public onlyOwner {
-      require(isFrozen(), "DAO is not already frozen");
-      freezeProposalCreatedBlock = 0;
-      freezeProposalVoteCount = 0;
+        require(isFrozen(), "DAO is not already frozen");
+        freezeProposalCreatedBlock = 0;
+        freezeProposalVoteCount = 0;
     }
 
     /// @notice Updates the veto votes threshold, only callable by the owner
     /// @param _vetoVotesThreshold The number of votes required to veto a transaction
-    function updateVetoVotesThreshold(uint256 _vetoVotesThreshold) external onlyOwner {
-      vetoVotesThreshold = _vetoVotesThreshold;
+    function updateVetoVotesThreshold(uint256 _vetoVotesThreshold)
+        external
+        onlyOwner
+    {
+        vetoVotesThreshold = _vetoVotesThreshold;
     }
 
     /// @notice Updates the freeze votes threshold, only callable by the owner
     /// @param _freezeVotesThreshold Number of freeze votes required to activate a freeze
-    function updateFreezeVotesThreshold(uint256 _freezeVotesThreshold) external onlyOwner {
-      freezeVotesThreshold = _freezeVotesThreshold;
+    function updateFreezeVotesThreshold(uint256 _freezeVotesThreshold)
+        external
+        onlyOwner
+    {
+        freezeVotesThreshold = _freezeVotesThreshold;
     }
 
     /// @notice Updates the freeze proposal blocks duration, only callable by the owner
     /// @param _freezeProposalBlockDuration The number of blocks a freeze proposal has to succeed
-    function updateFreezeProposalBlockDuration(uint256 _freezeProposalBlockDuration) external onlyOwner {
-      freezeProposalBlockDuration = _freezeProposalBlockDuration;
+    function updateFreezeProposalBlockDuration(
+        uint256 _freezeProposalBlockDuration
+    ) external onlyOwner {
+        freezeProposalBlockDuration = _freezeProposalBlockDuration;
     }
 
     /// @notice Updates the freeze block duration, only callable by the owner
     /// @param _freezeBlockDuration The number of blocks a freeze last, from time of freeze proposal creation
-    function updateFreezeBlockDuration(uint256 _freezeBlockDuration) external onlyOwner {
-      freezeBlockDuration = _freezeBlockDuration;
+    function updateFreezeBlockDuration(uint256 _freezeBlockDuration)
+        external
+        onlyOwner
+    {
+        freezeBlockDuration = _freezeBlockDuration;
     }
 
     /// @notice Returns whether the specified transaction has been vetoed

--- a/contracts/VetoERC20Voting.sol
+++ b/contracts/VetoERC20Voting.sol
@@ -7,31 +7,44 @@ import "./TransactionHasher.sol";
 import "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/governance/utils/IVotes.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 /// @notice A contract for casting veto votes with an ERC20 votes token
-contract VetoERC20Voting is IVetoERC20Voting, TransactionHasher, Initializable {
-    bool public isFrozen;
-    uint256 public vetoVotesThreshold;
-    uint256 public freezeVotesThreshold;
+contract VetoERC20Voting is IVetoERC20Voting, TransactionHasher, Initializable, Ownable {
+    uint256 public vetoVotesThreshold; // Number of votes required to veto a transaction
+    uint256 public freezeVotesThreshold; // Number of freeze votes required to activate a freeze
+    uint256 public freezeProposalCreatedBlock; // Block number the freeze proposal was created at
+    uint256 public freezeProposalVoteCount; // Number of accrued freeze votes
+    uint256 public freezeProposalBlockDuration; // Number of blocks a freeze proposal has to succeed
+    uint256 public freezeBlockDuration; // Number of blocks a freeze last, from time of freeze proposal creation
     IVotes public votesToken;
     IVetoGuard public vetoGuard;
     mapping(bytes32 => uint256) public transactionVetoVotes;
-    mapping(bytes32 => uint256) public transactionFreezeVotes;
     mapping(address => mapping(bytes32 => bool)) public userHasVoted;
+    mapping(address => mapping(uint256 => bool)) public userHasFreezeVoted;
 
     /// @notice Initializes the contract that can only be called once
+    /// @param _owner The owner address that can update configurable parameters
     /// @param _vetoVotesThreshold The number of votes required to veto a transaction
     /// @param _freezeVotesThreshold The number of votes required to freeze the DAO
+    /// @param _freezeProposalBlockDuration The number of blocks a freeze proposal has to succeed
+    /// @param _freezeBlockDuration The number of blocks a freeze last, from time of freeze proposal creation
     /// @param _votesToken The address of the VotesToken contract
     /// @param _vetoGuard The address of the VetoGuard contract
     function initialize(
+        address _owner,
         uint256 _vetoVotesThreshold,
         uint256 _freezeVotesThreshold,
+        uint256 _freezeProposalBlockDuration,
+        uint256 _freezeBlockDuration,
         address _votesToken,
         address _vetoGuard
     ) external initializer {
+        _transferOwnership(_owner);
         vetoVotesThreshold = _vetoVotesThreshold;
         freezeVotesThreshold = _freezeVotesThreshold;
+        freezeProposalBlockDuration = _freezeProposalBlockDuration;
+        freezeBlockDuration = _freezeBlockDuration;
         votesToken = IVotes(_votesToken);
         vetoGuard = IVetoGuard(_vetoGuard);
     }
@@ -59,23 +72,91 @@ contract VetoERC20Voting is IVetoERC20Voting, TransactionHasher, Initializable {
             queuedBlockNumber - 1
         );
 
+        require(vetoVotes > 0, "User has no votes");
+
         // Add the user votes to the veto vote count for this transaction
         transactionVetoVotes[_transactionHash] += vetoVotes;
 
         // If the user is voting to freeze, count that vote as well
         if (_freeze) {
-            transactionFreezeVotes[_transactionHash] += vetoVotes;
-            // If enough freeze votes have been casted, then freeze the DAO
-            if (
-                !isFrozen &&
-                transactionFreezeVotes[_transactionHash] > freezeVotesThreshold
-            ) isFrozen = true;
+            castFreezeVote();
         }
 
         // User has voted
         userHasVoted[msg.sender][_transactionHash] = true;
 
         emit VetoVoteCast(msg.sender, _transactionHash, vetoVotes, _freeze);
+    }
+
+    /// @notice Allows a user to cast a freeze vote if there is an active freeze proposal
+    /// @notice If there isn't an active freeze proposal, it is created and the user's votes are cast
+    function castFreezeVote() public {
+        uint256 userVotes;
+
+        if (
+            block.number >
+            freezeProposalCreatedBlock + freezeProposalBlockDuration
+        ) {
+            // Create freeze proposal, set total votes to msg.sender's vote count
+            freezeProposalCreatedBlock = block.number;
+
+            userVotes = votesToken.getPastVotes(
+                msg.sender,
+                freezeProposalCreatedBlock - 1
+            );
+
+            freezeProposalVoteCount = userVotes;
+
+            emit FreezeProposalCreated(msg.sender);
+        } else {
+            // There is an existing freeze proposal, count user's votes
+            require(
+                !userHasFreezeVoted[msg.sender][freezeProposalCreatedBlock],
+                "User has already voted"
+            );
+
+            userVotes = votesToken.getPastVotes(
+                msg.sender,
+                freezeProposalCreatedBlock - 1
+            );
+
+            freezeProposalVoteCount += userVotes;
+        }
+
+        userHasFreezeVoted[msg.sender][freezeProposalCreatedBlock] = true;
+
+        emit FreezeVoteCast(msg.sender, userVotes);
+    }
+
+    /// @notice Unfreezes the DAO, only callable by the owner
+    function defrost() public onlyOwner {
+      require(isFrozen(), "DAO is not already frozen");
+      freezeProposalCreatedBlock = 0;
+      freezeProposalVoteCount = 0;
+    }
+
+    /// @notice Updates the veto votes threshold, only callable by the owner
+    /// @param _vetoVotesThreshold The number of votes required to veto a transaction
+    function updateVetoVotesThreshold(uint256 _vetoVotesThreshold) external onlyOwner {
+      vetoVotesThreshold = _vetoVotesThreshold;
+    }
+
+    /// @notice Updates the freeze votes threshold, only callable by the owner
+    /// @param _freezeVotesThreshold Number of freeze votes required to activate a freeze
+    function updateFreezeVotesThreshold(uint256 _freezeVotesThreshold) external onlyOwner {
+      freezeVotesThreshold = _freezeVotesThreshold;
+    }
+
+    /// @notice Updates the freeze proposal blocks duration, only callable by the owner
+    /// @param _freezeProposalBlockDuration The number of blocks a freeze proposal has to succeed
+    function updateFreezeProposalBlockDuration(uint256 _freezeProposalBlockDuration) external onlyOwner {
+      freezeProposalBlockDuration = _freezeProposalBlockDuration;
+    }
+
+    /// @notice Updates the freeze block duration, only callable by the owner
+    /// @param _freezeBlockDuration The number of blocks a freeze last, from time of freeze proposal creation
+    function updateFreezeBlockDuration(uint256 _freezeBlockDuration) external onlyOwner {
+      freezeBlockDuration = _freezeBlockDuration;
     }
 
     /// @notice Returns whether the specified transaction has been vetoed
@@ -101,7 +182,8 @@ contract VetoERC20Voting is IVetoERC20Voting, TransactionHasher, Initializable {
         address payable refundReceiver
     ) external view returns (bool) {
         return
-            isFrozen || transactionVetoVotes[
+            isFrozen() ||
+            transactionVetoVotes[
                 getTransactionHash(
                     to,
                     value,
@@ -113,7 +195,8 @@ contract VetoERC20Voting is IVetoERC20Voting, TransactionHasher, Initializable {
                     gasToken,
                     refundReceiver
                 )
-            ] > vetoVotesThreshold;
+            ] >
+            vetoVotesThreshold;
     }
 
     /// @notice Returns the number of votes that have been cast to veto the specified transaction
@@ -154,41 +237,16 @@ contract VetoERC20Voting is IVetoERC20Voting, TransactionHasher, Initializable {
             ];
     }
 
-    /// @notice Returns the number of votes that have been cast to freeze the DAO
-    /// @param to Destination address.
-    /// @param value Ether value.
-    /// @param data Data payload.
-    /// @param operation Operation type.
-    /// @param safeTxGas Gas that should be used for the safe transaction.
-    /// @param baseGas Gas costs for that are independent of the transaction execution(e.g. base transaction fee, signature check, payment of the refund)
-    /// @param gasPrice Maximum gas price that should be used for this transaction.
-    /// @param gasToken Token address (or 0 if ETH) that is used for the payment.
-    /// @param refundReceiver Address of receiver of gas payment (or 0 if tx.origin).
-    /// @return uint256 The number of freeze votes that have been cast
-    function getFreezeVotes(
-        address to,
-        uint256 value,
-        bytes memory data,
-        Enum.Operation operation,
-        uint256 safeTxGas,
-        uint256 baseGas,
-        uint256 gasPrice,
-        address gasToken,
-        address payable refundReceiver
-    ) external view returns (uint256) {
-        return
-            transactionFreezeVotes[
-                getTransactionHash(
-                    to,
-                    value,
-                    data,
-                    operation,
-                    safeTxGas,
-                    baseGas,
-                    gasPrice,
-                    gasToken,
-                    refundReceiver
-                )
-            ];
+    /// @notice Returns true if the DAO is currently frozen
+    /// @return bool Indicates whether the DAO is currently frozen
+    function isFrozen() public view returns (bool) {
+        if (
+            freezeProposalVoteCount > freezeVotesThreshold &&
+            block.number < freezeProposalCreatedBlock + freezeBlockDuration
+        ) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/contracts/VetoERC20Voting.sol
+++ b/contracts/VetoERC20Voting.sol
@@ -153,4 +153,42 @@ contract VetoERC20Voting is IVetoERC20Voting, TransactionHasher, Initializable {
                 )
             ];
     }
+
+    /// @notice Returns the number of votes that have been cast to freeze the DAO
+    /// @param to Destination address.
+    /// @param value Ether value.
+    /// @param data Data payload.
+    /// @param operation Operation type.
+    /// @param safeTxGas Gas that should be used for the safe transaction.
+    /// @param baseGas Gas costs for that are independent of the transaction execution(e.g. base transaction fee, signature check, payment of the refund)
+    /// @param gasPrice Maximum gas price that should be used for this transaction.
+    /// @param gasToken Token address (or 0 if ETH) that is used for the payment.
+    /// @param refundReceiver Address of receiver of gas payment (or 0 if tx.origin).
+    /// @return uint256 The number of freeze votes that have been cast
+    function getFreezeVotes(
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation,
+        uint256 safeTxGas,
+        uint256 baseGas,
+        uint256 gasPrice,
+        address gasToken,
+        address payable refundReceiver
+    ) external view returns (uint256) {
+        return
+            transactionFreezeVotes[
+                getTransactionHash(
+                    to,
+                    value,
+                    data,
+                    operation,
+                    safeTxGas,
+                    baseGas,
+                    gasPrice,
+                    gasToken,
+                    refundReceiver
+                )
+            ];
+    }
 }

--- a/contracts/VetoERC20Voting.sol
+++ b/contracts/VetoERC20Voting.sol
@@ -200,7 +200,6 @@ contract VetoERC20Voting is
         address payable refundReceiver
     ) external view returns (bool) {
         return
-            isFrozen() ||
             transactionVetoVotes[
                 getTransactionHash(
                     to,
@@ -213,8 +212,7 @@ contract VetoERC20Voting is
                     gasToken,
                     refundReceiver
                 )
-            ] >
-            vetoVotesThreshold;
+            ] > vetoVotesThreshold;
     }
 
     /// @notice Returns the number of votes that have been cast to veto the specified transaction

--- a/contracts/VetoGuard.sol
+++ b/contracts/VetoGuard.sol
@@ -173,6 +173,8 @@ contract VetoGuard is
             ),
             "Transaction has been vetoed"
         );
+
+        require(!vetoERC20Voting.isFrozen(), "DAO is frozen");
     }
 
     /// @notice Does checks after transaction is executed on the Gnosis Safe

--- a/contracts/VetoGuard.sol
+++ b/contracts/VetoGuard.sol
@@ -5,7 +5,7 @@ import "./interfaces/IVetoGuard.sol";
 import "./interfaces/IVetoERC20Voting.sol";
 import "./interfaces/IGnosisSafe.sol";
 import "./TransactionHasher.sol";
-import "@gnosis.pm/zodiac/contracts/guard/BaseGuard.sol";
+import "./FractalBaseGuard.sol";
 import "@gnosis.pm/zodiac/contracts/factory/FactoryFriendly.sol";
 import "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 
@@ -13,7 +13,7 @@ import "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 contract VetoGuard is
     TransactionHasher,
     FactoryFriendly,
-    BaseGuard,
+    FractalBaseGuard,
     IVetoGuard
 {
     uint256 public executionDelayBlocks;
@@ -195,5 +195,21 @@ contract VetoGuard is
         returns (uint256)
     {
         return transactionQueuedBlock[_transactionHash];
+    }
+
+
+    /// @notice Can be used to check if this contract supports the specified interface
+    /// @param interfaceId The bytes representing the interfaceId being checked
+    /// @return bool True if this contract supports the checked interface
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override (FractalBaseGuard)
+        returns (bool)
+    {
+        return
+            interfaceId == type(IVetoGuard).interfaceId ||
+            super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/interfaces/IVetoERC20Voting.sol
+++ b/contracts/interfaces/IVetoERC20Voting.sol
@@ -11,19 +11,18 @@ interface IVetoERC20Voting {
         bool freeze
     );
 
-    event FreezeVoteCast(
-        address indexed voter,
-        uint256 votesCast
-    );
+    event FreezeVoteCast(address indexed voter, uint256 votesCast);
 
-    event FreezeProposalCreated(
-        address indexed creator
-    );
+    event FreezeProposalCreated(address indexed creator);
 
     /// @notice Allows the msg.sender to cast veto and freeze votes on the specified transaction
     /// @param _transactionHash The hash of the transaction data
     /// @param _freeze Bool indicating whether the voter thinks the DAO should also be frozen
     function castVetoVote(bytes32 _transactionHash, bool _freeze) external;
+
+    /// @notice Allows a user to cast a freeze vote if there is an active freeze proposal
+    /// @notice If there isn't an active freeze proposal, it is created and the user's votes are cast
+    function castFreezeVote() external;
 
     /// @notice Returns whether the specified functions has been vetoed
     /// @param to Destination address.
@@ -47,4 +46,8 @@ interface IVetoERC20Voting {
         address gasToken,
         address payable refundReceiver
     ) external view returns (bool);
+
+    /// @notice Returns true if the DAO is currently frozen
+    /// @return bool Indicates whether the DAO is currently frozen
+    function isFrozen() external view returns (bool);
 }

--- a/contracts/interfaces/IVetoERC20Voting.sol
+++ b/contracts/interfaces/IVetoERC20Voting.sol
@@ -11,6 +11,15 @@ interface IVetoERC20Voting {
         bool freeze
     );
 
+    event FreezeVoteCast(
+        address indexed voter,
+        uint256 votesCast
+    );
+
+    event FreezeProposalCreated(
+        address indexed creator
+    );
+
     /// @notice Allows the msg.sender to cast veto and freeze votes on the specified transaction
     /// @param _transactionHash The hash of the transaction data
     /// @param _freeze Bool indicating whether the voter thinks the DAO should also be frozen

--- a/contracts/interfaces/IVetoERC20Voting.sol
+++ b/contracts/interfaces/IVetoERC20Voting.sol
@@ -7,14 +7,14 @@ interface IVetoERC20Voting {
     event VetoVoteCast(
         address indexed voter,
         bytes32 indexed transactionHash,
-        uint256 votesCast
+        uint256 votesCast,
+        bool freeze
     );
 
-    /// @notice Allows the msg.sender to cast veto votes on the specified transaction
+    /// @notice Allows the msg.sender to cast veto and freeze votes on the specified transaction
     /// @param _transactionHash The hash of the transaction data
-    function castVetoVote(
-        bytes32 _transactionHash
-    ) external;
+    /// @param _freeze Bool indicating whether the voter thinks the DAO should also be frozen
+    function castVetoVote(bytes32 _transactionHash, bool _freeze) external;
 
     /// @notice Returns whether the specified functions has been vetoed
     /// @param to Destination address.

--- a/contracts/interfaces/IVetoGuard.sol
+++ b/contracts/interfaces/IVetoGuard.sol
@@ -4,13 +4,6 @@ pragma solidity ^0.8.0;
 import "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 
 interface IVetoGuard {
-    enum TransactionState {
-        pending,
-        queued,
-        readyToExecute,
-        vetoed
-    }
-
     event VetoGuardSetup(
         address creator,
         uint256 executionDelayBlocks,

--- a/test/VetoGuard-Gnosis.test.ts
+++ b/test/VetoGuard-Gnosis.test.ts
@@ -136,6 +136,7 @@ describe("Gnosis Safe", () => {
     // Initialize VetoERC20Voting contract
     await vetoERC20Voting.initialize(
       1000,
+      1000,
       votesToken.address,
       vetoGuard.address
     );
@@ -399,7 +400,7 @@ describe("Gnosis Safe", () => {
     );
 
     // Vetoer 1 casts 500 veto votes
-    await vetoERC20Voting.connect(tokenVetoer1).castVetoVote(txHash);
+    await vetoERC20Voting.connect(tokenVetoer1).castVetoVote(txHash, false);
 
     // 500 veto votes have been cast
     expect(
@@ -498,10 +499,10 @@ describe("Gnosis Safe", () => {
     );
 
     // Vetoer 1 casts 500 veto votes
-    await vetoERC20Voting.connect(tokenVetoer1).castVetoVote(txHash);
+    await vetoERC20Voting.connect(tokenVetoer1).castVetoVote(txHash, false);
 
     // Vetoer 2 casts 600 veto votes
-    await vetoERC20Voting.connect(tokenVetoer2).castVetoVote(txHash);
+    await vetoERC20Voting.connect(tokenVetoer2).castVetoVote(txHash, false);
 
     // 1100 veto votes have been cast
     expect(
@@ -599,10 +600,10 @@ describe("Gnosis Safe", () => {
     );
 
     // Vetoer 1 casts 500 veto votes
-    await vetoERC20Voting.connect(tokenVetoer1).castVetoVote(txHash);
+    await vetoERC20Voting.connect(tokenVetoer1).castVetoVote(txHash, false);
 
     await expect(
-      vetoERC20Voting.connect(tokenVetoer1).castVetoVote(txHash)
+      vetoERC20Voting.connect(tokenVetoer1).castVetoVote(txHash, false)
     ).to.be.revertedWith("User has already voted");
   });
 
@@ -633,7 +634,7 @@ describe("Gnosis Safe", () => {
     );
 
     await expect(
-      vetoERC20Voting.connect(tokenVetoer1).castVetoVote(txHash)
+      vetoERC20Voting.connect(tokenVetoer1).castVetoVote(txHash, false)
     ).to.be.revertedWith("Transaction has not yet been queued");
   });
 });

--- a/test/VetoGuard-Gnosis.test.ts
+++ b/test/VetoGuard-Gnosis.test.ts
@@ -1143,7 +1143,7 @@ describe.only("Gnosis Safe", () => {
       expect(await vetoERC20Voting.freezeProposalVoteCount()).to.eq(500);
     });
 
-    it("Defrosted DAOs may execute txs", async () => {
+    it("Prev. Frozen DAOs may execute txs after the frozen period", async () => {
       // Vetoer 1 casts 500 veto votes and 500 freeze votes
       await vetoERC20Voting.connect(tokenVetoer1).castFreezeVote();
       // Vetoer 2 casts 600 veto votes
@@ -1226,7 +1226,7 @@ describe.only("Gnosis Safe", () => {
       ).to.emit(gnosisSafe, "ExecutionSuccess");
     });
 
-    it.only("Prev. Frozen DAOs may execute txs after the frozen period", async () => {
+    it("Defrosted DAOs may execute txs", async () => {
       // Vetoer 1 casts 500 veto votes and 500 freeze votes
       await vetoERC20Voting.connect(tokenVetoer1).castFreezeVote();
       // Vetoer 2 casts 600 veto votes
@@ -1289,6 +1289,32 @@ describe.only("Gnosis Safe", () => {
           signatureBytes1
         )
       ).to.emit(gnosisSafe, "ExecutionSuccess");
+    });
+
+    it.only("You must have voting weight to cast a freeze vote", async () => {
+      await expect(
+        vetoERC20Voting.connect(vetoGuardOwner).castFreezeVote()
+      ).to.be.revertedWith("User has no votes");
+    });
+
+    it("Only owner methods must be called by vetoGuard owner", async () => {
+      await expect(
+        vetoERC20Voting.connect(tokenVetoer1).defrost()
+      ).to.be.revertedWith("Ownable: caller is not the owner");
+      await expect(
+        vetoERC20Voting.connect(tokenVetoer1).updateVetoVotesThreshold(0)
+      ).to.be.revertedWith("Ownable: caller is not the owner");
+      await expect(
+        vetoERC20Voting.connect(tokenVetoer1).updateFreezeVotesThreshold(0)
+      ).to.be.revertedWith("Ownable: caller is not the owner");
+      await expect(
+        vetoERC20Voting
+          .connect(tokenVetoer1)
+          .updateFreezeProposalBlockDuration(0)
+      ).to.be.revertedWith("Ownable: caller is not the owner");
+      await expect(
+        vetoERC20Voting.connect(tokenVetoer1).updateFreezeBlockDuration(0)
+      ).to.be.revertedWith("Ownable: caller is not the owner");
     });
   });
 });

--- a/test/VetoGuard-Gnosis.test.ts
+++ b/test/VetoGuard-Gnosis.test.ts
@@ -956,7 +956,7 @@ describe.only("Gnosis Safe", () => {
           tx2.refundReceiver,
           signatureBytes2
         )
-      ).to.be.revertedWith("Transaction has been vetoed");
+      ).to.be.revertedWith("DAO is frozen");
     });
 
     it("A DAO may be frozen ind. of a veto ", async () => {
@@ -1021,7 +1021,7 @@ describe.only("Gnosis Safe", () => {
           tx1.refundReceiver,
           signatureBytes1
         )
-      ).to.be.revertedWith("Transaction has been vetoed");
+      ).to.be.revertedWith("DAO is frozen");
     });
 
     it("A DAO may execute txs during a the freeze proposal period if the freeze threshold is not met", async () => {
@@ -1135,7 +1135,7 @@ describe.only("Gnosis Safe", () => {
       expect(await vetoERC20Voting.isFrozen()).to.eq(false);
     });
 
-    it("A user cannot vote twice to freeze a dao during a voting period", async () => {
+    it("A user cannot vote twice to freeze a dao during the same voting period", async () => {
       await vetoERC20Voting.connect(tokenVetoer1).castFreezeVote();
       await expect(
         vetoERC20Voting.connect(tokenVetoer1).castFreezeVote()
@@ -1202,7 +1202,7 @@ describe.only("Gnosis Safe", () => {
           tx1.refundReceiver,
           signatureBytes1
         )
-      ).to.be.revertedWith("Transaction has been vetoed");
+      ).to.be.revertedWith("DAO is frozen");
 
       for (let i = 0; i < 100; i++) {
         await network.provider.send("evm_mine");
@@ -1291,7 +1291,11 @@ describe.only("Gnosis Safe", () => {
       ).to.emit(gnosisSafe, "ExecutionSuccess");
     });
 
-    it.only("You must have voting weight to cast a freeze vote", async () => {
+    it("You must have voting weight to cast a freeze vote", async () => {
+      await expect(
+        vetoERC20Voting.connect(vetoGuardOwner).castFreezeVote()
+      ).to.be.revertedWith("User has no votes");
+      vetoERC20Voting.connect(tokenVetoer1).castFreezeVote();
       await expect(
         vetoERC20Voting.connect(vetoGuardOwner).castFreezeVote()
       ).to.be.revertedWith("User has no votes");

--- a/test/VetoGuard-Gnosis.test.ts
+++ b/test/VetoGuard-Gnosis.test.ts
@@ -186,6 +186,20 @@ describe("Gnosis Safe", () => {
   });
 
   describe("VetoGuard Functionality", () => {
+    it("Supports ERC-165", async () => {
+      // Supports IVetoGuard interface
+      expect(await vetoGuard.supportsInterface("0x4877b8b2")).to.eq(true);
+
+      // Supports IGuard interface
+      expect(await vetoGuard.supportsInterface("0xe6d7a83a")).to.eq(true);
+
+      // Supports IERC-165 interface
+      expect(await vetoGuard.supportsInterface("0x01ffc9a7")).to.eq(true);
+
+      // Doesn't support random interface
+      expect(await vetoGuard.supportsInterface("0x00000000")).to.eq(false);
+    });
+
     it("A transaction can be queued and executed", async () => {
       // Create transaction to set the guard address
       const tokenTransferData = votesToken.interface.encodeFunctionData(

--- a/test/VetoGuard-Gnosis.test.ts
+++ b/test/VetoGuard-Gnosis.test.ts
@@ -708,7 +708,7 @@ describe("Gnosis Safe", () => {
     expect(await votesToken.balanceOf(gnosisSafe.address)).to.eq(1);
   });
 
-  it.only("A frozen DAO cannot execute any transactions", async () => {
+  it("A frozen DAO cannot execute any transactions", async () => {
     // Create transaction to set the guard address
     const tokenTransferData1 = votesToken.interface.encodeFunctionData(
       "transfer",

--- a/test/VetoGuard-Gnosis.test.ts
+++ b/test/VetoGuard-Gnosis.test.ts
@@ -22,7 +22,7 @@ import {
   abiSafe,
 } from "./helpers";
 
-describe.only("Gnosis Safe", () => {
+describe("Gnosis Safe", () => {
   // Factories
   let gnosisFactory: Contract;
 


### PR DESCRIPTION
Description
This PR primarily adds the freeze feature within the vetoERC20Voting.sol contract. 

The Freeze Functionality
This Freeze feature is implemented in one method which sets a proposal to freeze a DAO where users may vote w/ their parent token voting weight by using the same method (CastFreezeVote). 

The users which believe the DAO should be frozen may vote within the vote period defined by the DAO. If a vote does not succeed, the signers may continue operating as normal - if it does - it places a period if inaction on the dao where no txs may be executed.

The DAO may be defrosted by a proposal from the parent DAO or wait until the frozen period is over which is also defined by the DAO.

Notes
The state vars for voting period, threshold, and frozen period may be updated and changed by the Parent DAO.

Issue (if applicable)

Testing
Once the branch has been pulled down locally, run:
npm install
npx hardhat test

Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/69045872/193152273-8dae72e3-1019-48e7-8828-b87b3c480a5a.png)
