### PR TITLE
Fractal module

### DIFF
--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -1,3 +1,4 @@
+//SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
 import "@gnosis.pm/zodiac/contracts/core/Module.sol";
@@ -41,20 +42,15 @@ contract FractalModule is Module {
 
     function batchExecTxs(bytes memory execTxData) public OnlyAuthorized {
         (
-            address[] memory targets,
-            uint256[] memory values,
-            bytes[] memory datas,
-            Enum.Operation[] memory operations
-        ) = abi.decode(
-                execTxData,
-                (address[], uint256[], bytes[], Enum.Operation[])
-            );
-        for (uint256 i; i < targets.length; i++) {
-            require(
-                exec(targets[i], values[i], datas[i], operations[i]),
-                "Module transaction failed"
-            );
-        }
+            address target,
+            uint256 value,
+            bytes memory data,
+            Enum.Operation operation
+        ) = abi.decode(execTxData, (address, uint256, bytes, Enum.Operation));
+        require(
+            exec(target, value, data, operation),
+            "Module transaction failed"
+        );
     }
 
     function addControllers(address[] memory _controllers) public onlyOwner {
@@ -73,4 +69,15 @@ contract FractalModule is Module {
         }
         emit ControllersRemoved(_controllers);
     }
+
+    // function supportsInterface(bytes4 interfaceId)
+    //     external
+    //     pure
+    //     override
+    //     returns (bool)
+    // {
+    //     return
+    //         interfaceId == type(IGuard).interfaceId || // 0xe6d7a83a
+    //         interfaceId == type(IERC165).interfaceId; // 0x01ffc9a7
+    // }
 }

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -5,6 +5,8 @@ import "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 
 contract FractalModule is Module {
     mapping(address => bool) controllers; // A DAO may authorize users to act on the behalf of the parent DAO.
+    event ControllersAdded(address[] controllers);
+    event ControllersRemoved(address[] controllers);
 
     /**
      * @dev Throws if called by any account other than the owner.
@@ -55,6 +57,7 @@ contract FractalModule is Module {
         for (uint256 i; i < _controllers.length; i++) {
             controllers[_controllers[i]] = true;
         }
+        emit ControllersAdded(_controllers);
     }
 
     function removeControllers(address[] memory _controllers)
@@ -64,5 +67,6 @@ contract FractalModule is Module {
         for (uint256 i; i < _controllers.length; i++) {
             controllers[_controllers[i]] = false;
         }
+        emit ControllersRemoved(_controllers);
     }
 }

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -58,7 +58,7 @@ contract FractalModule is IFractalModule, Module {
         for (uint256 i; i < controllersLength; ) {
             controllers[_controllers[i]] = true;
             unchecked {
-                i++;
+                ++i;
             }
         }
         emit ControllersAdded(_controllers);
@@ -74,7 +74,7 @@ contract FractalModule is IFractalModule, Module {
         for (uint256 i; i < controllersLength; ) {
             controllers[_controllers[i]] = false;
             unchecked {
-                i++;
+                ++i;
             }
         }
         emit ControllersRemoved(_controllers);

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.0;
 import "@gnosis.pm/zodiac/contracts/core/Module.sol";
 
 contract FractalModule is Module {
+    mapping(address => bool) controllers; // A DAO may authorize users to act on the behalf of the parent DAO.
+
     /// @dev Initialize function
     /// @param initializeParams Parameters of initialization encoded
     function setUp(bytes memory initializeParams) public override initializer {
@@ -10,11 +12,31 @@ contract FractalModule is Module {
         (
             address _owner, // Controlling DAO
             address _avatar, // GSafe
-            address _target // GSafe or Modifier
-        ) = abi.decode(initializeParams, (address, address, address));
+            address _target, // GSafe or Modifier
+            address[] memory _controllers // Authorized controllers
+        ) = abi.decode(
+                initializeParams,
+                (address, address, address, address[])
+            );
 
         setAvatar(_avatar);
         setTarget(_target);
         transferOwnership(_owner);
+        for (uint256 i; i < _controllers.length; i++) {
+            controllers[_controllers[i]] = true;
+        }
     }
+
+    function addController(address[] memory _controllers) public onlyOwner {
+        for (uint256 i; i < _controllers.length; i++) {
+            controllers[_controllers[i]] = true;
+        }
+    }
+
+    // function clawBack(address[] memory tokens) public {
+    //     require(
+    //         exec(target, value, data, operation),
+    //         "Module transaction failed"
+    //     );
+    // }
 }

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -74,6 +74,9 @@ contract FractalModule is IFractalModule, Module {
         emit ControllersRemoved(_controllers);
     }
 
+    /// @notice Returns whether a given interface ID is supported
+    /// @param interfaceId An interface ID bytes4 as defined by ERC-165
+    /// @return bool Indicates whether the interface is supported
     function supportsInterface(bytes4 interfaceId)
         external
         pure

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -38,7 +38,7 @@ contract FractalModule is IFractalModule, Module {
 
     /// @notice Allows an authorized user to exec a Gnosis Safe tx via the module
     /// @param execTxData Data payload of module transaction.
-    function batchExecTxs(bytes memory execTxData) public onlyAuthorized {
+    function execTx(bytes memory execTxData) public onlyAuthorized {
         (
             address _target,
             uint256 _value,

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -25,16 +25,16 @@ contract FractalModule is Module {
         __Ownable_init();
         (
             address _owner, // Controlling DAO
-            address _avatar, // GSafe
-            address _target, // GSafe or Modifier
+            address _avatar, // GSafe // Address(0) == msg.sender
+            address _target, // GSafe or Modifier  // Address(0) == msg.sender
             address[] memory _controllers // Authorized controllers
         ) = abi.decode(
                 initializeParams,
                 (address, address, address, address[])
             );
-
-        setAvatar(_avatar);
-        setTarget(_target);
+    
+        setAvatar(_avatar == address(0) ? msg.sender : _avatar);
+        setTarget(_target == address(0) ? msg.sender : _target);
         addControllers(_controllers);
         transferOwnership(_owner);
     }

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -12,7 +12,7 @@ contract FractalModule is Module {
     /**
      * @dev Throws if called by any account other than the owner.
      */
-    modifier OnlyAuthorized() {
+    modifier onlyAuthorized() {
         require(
             owner() == msg.sender || controllers[msg.sender],
             "Not Authorized"
@@ -40,7 +40,7 @@ contract FractalModule is Module {
         transferOwnership(_owner);
     }
 
-    function batchExecTxs(bytes memory execTxData) public OnlyAuthorized {
+    function batchExecTxs(bytes memory execTxData) public onlyAuthorized {
         (
             address target,
             uint256 value,
@@ -69,15 +69,4 @@ contract FractalModule is Module {
         }
         emit ControllersRemoved(_controllers);
     }
-
-    // function supportsInterface(bytes4 interfaceId)
-    //     external
-    //     pure
-    //     override
-    //     returns (bool)
-    // {
-    //     return
-    //         interfaceId == type(IGuard).interfaceId || // 0xe6d7a83a
-    //         interfaceId == type(IERC165).interfaceId; // 0x01ffc9a7
-    // }
 }

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -1,0 +1,20 @@
+pragma solidity ^0.8.0;
+
+import "@gnosis.pm/zodiac/contracts/core/Module.sol";
+
+contract FractalModule is Module {
+    /// @dev Initialize function
+    /// @param initializeParams Parameters of initialization encoded
+    function setUp(bytes memory initializeParams) public override initializer {
+        __Ownable_init();
+        (
+            address _owner, // Controlling DAO
+            address _avatar, // GSafe
+            address _target // GSafe or Modifier
+        ) = abi.decode(initializeParams, (address, address, address));
+
+        setAvatar(_avatar);
+        setTarget(_target);
+        transferOwnership(_owner);
+    }
+}

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -22,9 +22,7 @@ contract FractalModule is Module {
         setAvatar(_avatar);
         setTarget(_target);
         transferOwnership(_owner);
-        for (uint256 i; i < _controllers.length; i++) {
-            controllers[_controllers[i]] = true;
-        }
+        addControllers(_controllers);
     }
 
     function addControllers(address[] memory _controllers) public onlyOwner {

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -32,19 +32,23 @@ contract FractalModule is Module {
                 initializeParams,
                 (address, address, address, address[])
             );
-    
+
         setAvatar(_avatar == address(0) ? msg.sender : _avatar);
         setTarget(_target == address(0) ? msg.sender : _target);
         addControllers(_controllers);
         transferOwnership(_owner);
     }
 
-    function batchExecTxs(
-        address[] memory targets,
-        uint256[] memory values,
-        bytes[] memory datas,
-        Enum.Operation[] memory operations
-    ) public OnlyAuthorized {
+    function batchExecTxs(bytes memory execTxData) public OnlyAuthorized {
+        (
+            address[] memory targets,
+            uint256[] memory values,
+            bytes[] memory datas,
+            Enum.Operation[] memory operations
+        ) = abi.decode(
+                execTxData,
+                (address[], uint256[], bytes[], Enum.Operation[])
+            );
         for (uint256 i; i < targets.length; i++) {
             require(
                 exec(targets[i], values[i], datas[i], operations[i]),

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.8.0;
 
 import "@gnosis.pm/zodiac/contracts/core/Module.sol";
+import "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 
 contract FractalModule is Module {
     mapping(address => bool) controllers; // A DAO may authorize users to act on the behalf of the parent DAO.
@@ -36,12 +37,19 @@ contract FractalModule is Module {
         transferOwnership(_owner);
     }
 
-    // function clawBack(address[] memory tokens) public OnlyAuthorized {
-    //     require(
-    //         exec(target, value, data, operation),
-    //         "Module transaction failed"
-    //     );
-    // }
+    function batchExecTxs(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory datas,
+        Enum.Operation[] memory operations
+    ) public OnlyAuthorized {
+        for (uint256 i; i < targets.length; i++) {
+            require(
+                exec(targets[i], values[i], datas[i], operations[i]),
+                "Module transaction failed"
+            );
+        }
+    }
 
     function addControllers(address[] memory _controllers) public onlyOwner {
         for (uint256 i; i < _controllers.length; i++) {
@@ -49,10 +57,12 @@ contract FractalModule is Module {
         }
     }
 
-    function removeControllers(address[] memory _controllers) external onlyOwner {
+    function removeControllers(address[] memory _controllers)
+        external
+        onlyOwner
+    {
         for (uint256 i; i < _controllers.length; i++) {
             controllers[_controllers[i]] = false;
         }
     }
-
 }

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -56,8 +56,12 @@ contract FractalModule is IFractalModule, Module {
     /// @notice Allows the module owner to add users which may exectxs
     /// @param _controllers Addresses added to the contoller list
     function addControllers(address[] memory _controllers) public onlyOwner {
-        for (uint256 i; i < _controllers.length; i++) {
+        uint256 controllersLength = _controllers.length;
+        for (uint256 i; i < controllersLength; ) {
             controllers[_controllers[i]] = true;
+            unchecked {
+                i++;
+            }
         }
         emit ControllersAdded(_controllers);
     }
@@ -68,8 +72,12 @@ contract FractalModule is IFractalModule, Module {
         external
         onlyOwner
     {
-        for (uint256 i; i < _controllers.length; i++) {
+        uint256 controllersLength = _controllers.length;
+        for (uint256 i; i < controllersLength; ) {
             controllers[_controllers[i]] = false;
+            unchecked {
+                i++;
+            }
         }
         emit ControllersRemoved(_controllers);
     }

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -5,6 +5,17 @@ import "@gnosis.pm/zodiac/contracts/core/Module.sol";
 contract FractalModule is Module {
     mapping(address => bool) controllers; // A DAO may authorize users to act on the behalf of the parent DAO.
 
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier OnlyAuthorized() {
+        require(
+            owner() == msg.sender || controllers[msg.sender],
+            "Not Authorized"
+        );
+        _;
+    }
+
     /// @dev Initialize function
     /// @param initializeParams Parameters of initialization encoded
     function setUp(bytes memory initializeParams) public override initializer {
@@ -21,9 +32,16 @@ contract FractalModule is Module {
 
         setAvatar(_avatar);
         setTarget(_target);
-        transferOwnership(_owner);
         addControllers(_controllers);
+        transferOwnership(_owner);
     }
+
+    // function clawBack(address[] memory tokens) public OnlyAuthorized {
+    //     require(
+    //         exec(target, value, data, operation),
+    //         "Module transaction failed"
+    //     );
+    // }
 
     function addControllers(address[] memory _controllers) public onlyOwner {
         for (uint256 i; i < _controllers.length; i++) {
@@ -31,16 +49,10 @@ contract FractalModule is Module {
         }
     }
 
-    function removeControllers(address[] memory _controllers) public onlyOwner {
+    function removeControllers(address[] memory _controllers) external onlyOwner {
         for (uint256 i; i < _controllers.length; i++) {
             controllers[_controllers[i]] = false;
         }
     }
 
-    // function clawBack(address[] memory tokens) public {
-    //     require(
-    //         exec(target, value, data, operation),
-    //         "Module transaction failed"
-    //     );
-    // }
 }

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -7,9 +7,7 @@ import "./interfaces/IFractalModule.sol";
 contract FractalModule is IFractalModule, Module {
     mapping(address => bool) public controllers; // A DAO may authorize users to act on the behalf of the parent DAO.
 
-    /**
-     * @dev Throws if called by any account other than the owner.
-     */
+    /// @dev Throws if called by any account other than the owner.
     modifier onlyAuthorized() {
         require(
             owner() == msg.sender || controllers[msg.sender],

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -27,9 +27,15 @@ contract FractalModule is Module {
         }
     }
 
-    function addController(address[] memory _controllers) public onlyOwner {
+    function addControllers(address[] memory _controllers) public onlyOwner {
         for (uint256 i; i < _controllers.length; i++) {
             controllers[_controllers[i]] = true;
+        }
+    }
+
+    function removeControllers(address[] memory _controllers) public onlyOwner {
+        for (uint256 i; i < _controllers.length; i++) {
+            controllers[_controllers[i]] = false;
         }
     }
 

--- a/contracts/FractalModule.sol
+++ b/contracts/FractalModule.sol
@@ -4,7 +4,7 @@ import "@gnosis.pm/zodiac/contracts/core/Module.sol";
 import "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
 
 contract FractalModule is Module {
-    mapping(address => bool) controllers; // A DAO may authorize users to act on the behalf of the parent DAO.
+    mapping(address => bool) public controllers; // A DAO may authorize users to act on the behalf of the parent DAO.
     event ControllersAdded(address[] controllers);
     event ControllersRemoved(address[] controllers);
 

--- a/contracts/interfaces/IFractalModule.sol
+++ b/contracts/interfaces/IFractalModule.sol
@@ -10,7 +10,7 @@ interface IFractalModule {
 
     /// @notice Allows an authorized user to exec a Gnosis Safe tx via the module
     /// @param execTxData Data payload of module transaction.
-    function batchExecTxs(bytes memory execTxData) external;
+    function execTx(bytes memory execTxData) external;
 
     /// @notice Allows the module owner to add users which may exectxs
     /// @param _controllers Addresses added to the contoller list

--- a/contracts/interfaces/IFractalModule.sol
+++ b/contracts/interfaces/IFractalModule.sol
@@ -1,0 +1,22 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+import "@gnosis.pm/safe-contracts/contracts/common/Enum.sol";
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+interface IFractalModule {
+    event ControllersAdded(address[] controllers);
+    event ControllersRemoved(address[] controllers);
+
+    /// @notice Allows an authorized user to exec a Gnosis Safe tx via the module
+    /// @param execTxData Data payload of module transaction.
+    function batchExecTxs(bytes memory execTxData) external;
+
+    /// @notice Allows the module owner to add users which may exectxs
+    /// @param _controllers Addresses added to the contoller list
+    function addControllers(address[] memory _controllers) external;
+
+    /// @notice Allows the module owner to remove users which may exectxs
+    /// @param _controllers Addresses removed to the contoller list
+    function removeControllers(address[] memory _controllers) external;
+}

--- a/test/Fractal-Module.test.ts
+++ b/test/Fractal-Module.test.ts
@@ -55,8 +55,6 @@ describe("Fractal-Module Integration", () => {
   );
 
   beforeEach(async () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    setTimeout(function () {}, 100);
     // Fork Goerli to use contracts deployed on Goerli
     await network.provider.request({
       method: "hardhat_reset",

--- a/test/Fractal-Module.test.ts
+++ b/test/Fractal-Module.test.ts
@@ -246,7 +246,7 @@ describe("Fractal-Module Integration", () => {
       expect(await fractalModule.controllers(owner3.address)).eq(false);
     });
 
-    it("Authorized users may exec txs => GS", async () => {
+    it.only("Authorized users may exec txs => GS", async () => {
       await gnosisFactory.createProxyWithCallback(
         gnosisSingletonAddress,
         bytecode,
@@ -273,8 +273,8 @@ describe("Fractal-Module Integration", () => {
       const txData =
         // eslint-disable-next-line camelcase
         abiCoder.encode(
-          ["address[]", "uint256[]", "bytes[]", "uint8[]"],
-          [[votesToken.address], [0], [clawBackCalldata], [0]]
+          ["address", "uint256", "bytes", "uint8"],
+          [votesToken.address, 0, clawBackCalldata, 0]
         );
 
       // REVERT => NOT AUTHORIZED

--- a/test/Fractal-Module.test.ts
+++ b/test/Fractal-Module.test.ts
@@ -297,25 +297,25 @@ describe("Fractal-Module Integration", () => {
         );
 
       // REVERT => NOT AUTHORIZED
-      await expect(fractalModule.batchExecTxs(txData)).to.be.revertedWith(
+      await expect(fractalModule.execTx(txData)).to.be.revertedWith(
         "Not Authorized"
       );
 
       // OWNER MAY EXECUTE
-      await expect(fractalModule.connect(owner1).batchExecTxs(txData)).to.emit(
+      await expect(fractalModule.connect(owner1).execTx(txData)).to.emit(
         gnosisSafe,
         "ExecutionFromModuleSuccess"
       );
 
       // Controller MAY EXECUTE
-      await expect(fractalModule.connect(owner2).batchExecTxs(txData)).to.emit(
+      await expect(fractalModule.connect(owner2).execTx(txData)).to.emit(
         gnosisSafe,
         "ExecutionFromModuleSuccess"
       );
 
       // REVERT => Execution Failure
       await expect(
-        fractalModule.connect(owner1).batchExecTxs(txData)
+        fractalModule.connect(owner1).execTx(txData)
       ).to.be.revertedWith("Module transaction failed");
 
       expect(await votesToken.balanceOf(gnosisSafe.address)).to.eq(0);

--- a/test/Fractal-Module.test.ts
+++ b/test/Fractal-Module.test.ts
@@ -2,10 +2,15 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
 import { BigNumber, Contract } from "ethers";
 import { ethers, network } from "hardhat";
-import { FractalModule, VotesToken__factory } from "../typechain-types";
+import {
+  FractalModule,
+  IFractalModule__factory,
+  VotesToken__factory,
+} from "../typechain-types";
 import { CallbackGnosis } from "../typechain-types/contracts/CallbackGnosis";
 import { CallbackGnosis__factory } from "../typechain-types/factories/contracts/CallbackGnosis__factory";
 import { FractalModule__factory } from "../typechain-types/factories/contracts/FractalModule__factory";
+import getInterfaceSelector from "./getInterfaceSelector";
 
 import {
   ifaceSafe,
@@ -205,6 +210,22 @@ describe("Fractal-Module Integration", () => {
       expect(await fractalModule.controllers(owner3.address)).eq(false);
     });
 
+    it("Supports the expected ERC165 interface", async () => {
+      await gnosisFactory.createProxyWithCallback(
+        gnosisSingletonAddress,
+        bytecode,
+        saltNum,
+        callback.address
+      );
+      // Supports Fractal Module
+      expect(
+        await fractalModule.supportsInterface(
+          // eslint-disable-next-line camelcase
+          getInterfaceSelector(IFractalModule__factory.createInterface())
+        )
+      ).to.eq(true);
+    });
+
     it("Setup Module w/ enabledModule event", async () => {
       await expect(
         gnosisFactory.createProxyWithCallback(
@@ -246,7 +267,7 @@ describe("Fractal-Module Integration", () => {
       expect(await fractalModule.controllers(owner3.address)).eq(false);
     });
 
-    it.only("Authorized users may exec txs => GS", async () => {
+    it("Authorized users may exec txs => GS", async () => {
       await gnosisFactory.createProxyWithCallback(
         gnosisSingletonAddress,
         bytecode,

--- a/test/Fractal-Module.ts
+++ b/test/Fractal-Module.ts
@@ -1,0 +1,310 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from "chai";
+import { BigNumber, Contract } from "ethers";
+import { ethers, network } from "hardhat";
+import {
+  FractalModule,
+  VetoGuard,
+  VetoGuard__factory,
+} from "../typechain-types";
+import { CallbackGnosis } from "../typechain-types/contracts/CallbackGnosis";
+import { CallbackGnosis__factory } from "../typechain-types/factories/contracts/CallbackGnosis__factory";
+import { FractalModule__factory } from "../typechain-types/factories/contracts/FractalModule__factory";
+
+import {
+  ifaceSafe,
+  abi,
+  abiSafe,
+  predictGnosisSafeCallbackAddress,
+  ifaceFactory,
+  calculateProxyAddress,
+  abiFactory,
+} from "./helpers";
+
+describe("Fractal-Module", () => {
+  // Factories
+  let gnosisFactory: Contract;
+
+  // Deployed contracts
+  let gnosisSafe: Contract;
+  let moduleFactory: Contract;
+  let moduleImpl: FractalModule;
+  let fractalModule: FractalModule;
+
+  let vetoGuard: VetoGuard;
+  let vetoImpl: VetoGuard;
+  let callback: CallbackGnosis;
+
+  // Wallets
+  let deployer: SignerWithAddress;
+  let owner1: SignerWithAddress;
+  let owner2: SignerWithAddress;
+  let owner3: SignerWithAddress;
+
+  let predictedFractalModule: string;
+  const abiCoder = new ethers.utils.AbiCoder(); // encode data
+  const gnosisFactoryAddress = "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2";
+  const gnosisSingletonAddress = "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552";
+  const threshold = 2;
+  let bytecode: string;
+  const saltNum = BigNumber.from(
+    "0x856d90216588f9ffc124d1480a440e1c012c7a816952bc968d737bae5d4e139c"
+  );
+
+  beforeEach(async () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    setTimeout(function () {}, 100);
+    // Fork Goerli to use contracts deployed on Goerli
+    await network.provider.request({
+      method: "hardhat_reset",
+      params: [
+        {
+          forking: {
+            jsonRpcUrl: process.env.GOERLI_PROVIDER
+              ? process.env.GOERLI_PROVIDER
+              : "",
+          },
+        },
+      ],
+    });
+
+    [deployer, owner1, owner2, owner3] = await ethers.getSigners();
+
+    gnosisFactory = new ethers.Contract(gnosisFactoryAddress, abi, deployer); // Gnosis Factory
+    moduleFactory = new ethers.Contract(
+      "0x00000000000DC7F163742Eb4aBEf650037b1f588",
+      // eslint-disable-next-line camelcase
+      abiFactory,
+      deployer
+    );
+
+    callback = await new CallbackGnosis__factory(deployer).deploy(); // Gnosis Callback
+
+    // DEPLOY GUARD
+    moduleImpl = await new FractalModule__factory(deployer).deploy();
+    const fractalModuleInit =
+      // eslint-disable-next-line camelcase
+      FractalModule__factory.createInterface().encodeFunctionData("avatar");
+
+    predictedFractalModule = await calculateProxyAddress(
+      moduleFactory,
+      moduleImpl.address,
+      fractalModuleInit,
+      "10031021"
+    );
+
+    fractalModule = await ethers.getContractAt(
+      "FractalModule",
+      predictedFractalModule
+    );
+
+    const moduleData = ifaceFactory.encodeFunctionData("deployModule", [
+      vetoImpl.address,
+      fractalModuleInit,
+      "10031021",
+    ]);
+
+    // SET GUARD
+    // const setGuardCalldata = ifaceSafe.encodeFunctionData("setGuard", [
+    //   predictedVetoGuard,
+    // ]);
+
+    // Setup GNOSIS
+    const createGnosisCalldata = ifaceSafe.encodeFunctionData("setup", [
+      [owner1.address, owner2.address, owner3.address, callback.address],
+      1,
+      ethers.constants.AddressZero,
+      ethers.constants.HashZero,
+      ethers.constants.AddressZero,
+      ethers.constants.AddressZero,
+      0,
+      ethers.constants.AddressZero,
+    ]);
+
+    // REMOVE OWNER
+    const removeCalldata = ifaceSafe.encodeFunctionData("removeOwner", [
+      owner3.address,
+      callback.address,
+      threshold,
+    ]);
+
+    // INIT GUARD
+    const initParams = abiCoder.encode(
+      ["uint256", "address", "address", "address"],
+      [10, owner1.address, owner1.address, ethers.constants.AddressZero]
+    );
+
+    const initGuard = vetoGuard.interface.encodeFunctionData("setUp", [
+      initParams,
+    ]);
+
+    // TX Array
+    const sigs =
+      "0x000000000000000000000000" +
+      callback.address.slice(2) +
+      "0000000000000000000000000000000000000000000000000000000000000000" +
+      "01";
+
+    const txdata = abiCoder.encode(
+      ["address[][]", "bytes[][]", "bool[]"],
+      [
+        [
+          [ethers.constants.AddressZero, moduleFactory.address], // SetupGnosis + Deploy Guard
+          [
+            ethers.constants.AddressZero, // setGuard Gnosis
+            ethers.constants.AddressZero, // remove owner + threshold
+            vetoGuard.address, // setup Guard
+          ],
+        ],
+        [
+          [createGnosisCalldata, moduleData],
+          [setGuardCalldata, removeCalldata, initGuard],
+        ],
+        [false, true],
+      ]
+    );
+    bytecode = abiCoder.encode(["bytes", "bytes"], [txdata, sigs]);
+
+    // Predidct Gnosis Safe
+    const predictedGnosisSafeAddress = await predictGnosisSafeCallbackAddress(
+      gnosisFactory.address,
+      bytecode,
+      saltNum,
+      callback.address,
+      gnosisSingletonAddress,
+      gnosisFactory
+    );
+
+    // Get Gnosis Safe contract
+    gnosisSafe = new ethers.Contract(
+      predictedGnosisSafeAddress,
+      abiSafe,
+      deployer
+    );
+  });
+
+  describe("Fractal Module Testing", () => {
+    it("Setup VetoGuard w/ ModuleProxyCreationEvent", async () => {
+      await expect(
+        gnosisFactory.createProxyWithCallback(
+          gnosisSingletonAddress,
+          bytecode,
+          saltNum,
+          callback.address
+        )
+      )
+        .to.emit(moduleFactory, "ModuleProxyCreation")
+        .withArgs(predictedVetoGuard, vetoImpl.address);
+      expect(await vetoGuard.executionDelayBlocks()).eq(10);
+      expect(await vetoGuard.vetoERC20Voting()).eq(owner1.address);
+      expect(await vetoGuard.gnosisSafe()).eq(gnosisSafe.address);
+    });
+
+    it("Setup Guard w/ changeGuard event", async () => {
+      await expect(
+        gnosisFactory.createProxyWithCallback(
+          gnosisSingletonAddress,
+          bytecode,
+          saltNum,
+          callback.address
+        )
+      )
+        .to.emit(gnosisSafe, "ChangedGuard")
+        .withArgs(vetoGuard.address);
+    });
+
+    it("Setup Gnosis Safe w/ removedOwner event", async () => {
+      await expect(
+        gnosisFactory.createProxyWithCallback(
+          gnosisSingletonAddress,
+          bytecode,
+          saltNum,
+          callback.address
+        )
+      )
+        .to.emit(gnosisSafe, "RemovedOwner")
+        .withArgs(callback.address);
+      expect(await gnosisSafe.isOwner(owner1.address)).eq(true);
+      expect(await gnosisSafe.isOwner(owner2.address)).eq(true);
+      expect(await gnosisSafe.isOwner(owner3.address)).eq(true);
+      expect(await gnosisSafe.isOwner(callback.address)).eq(false);
+      expect(await gnosisSafe.getThreshold()).eq(threshold);
+    });
+
+    it("Tx Fails w/ incorrect txCall", async () => {
+      const badData = ifaceSafe.encodeFunctionData("setup", [
+        [ethers.constants.AddressZero],
+        1,
+        ethers.constants.AddressZero,
+        ethers.constants.HashZero,
+        ethers.constants.AddressZero,
+        ethers.constants.AddressZero,
+        0,
+        ethers.constants.AddressZero,
+      ]);
+      const sigs =
+        "0x000000000000000000000000" +
+        callback.address.slice(2) +
+        "0000000000000000000000000000000000000000000000000000000000000000" +
+        "01";
+
+      const txdata = abiCoder.encode(
+        ["address[][]", "bytes[][]", "bool[]"],
+        [
+          [
+            [ethers.constants.AddressZero], // SetupGnosis + Deploy Guard
+          ],
+          [[badData]],
+          [false, true],
+        ]
+      );
+      bytecode = abiCoder.encode(["bytes", "bytes"], [txdata, sigs]);
+      await expect(
+        gnosisFactory.createProxyWithCallback(
+          gnosisSingletonAddress,
+          bytecode,
+          saltNum,
+          callback.address
+        )
+      ).to.be.revertedWith("CB001");
+    });
+
+    it("Tx Fails w/ incorrect GnosisTxCall", async () => {
+      const badData = ifaceSafe.encodeFunctionData("setup", [
+        [ethers.constants.AddressZero],
+        1,
+        ethers.constants.AddressZero,
+        ethers.constants.HashZero,
+        ethers.constants.AddressZero,
+        ethers.constants.AddressZero,
+        0,
+        ethers.constants.AddressZero,
+      ]);
+      const sigs =
+        "0x000000000000000000000000" +
+        callback.address.slice(2) +
+        "0000000000000000000000000000000000000000000000000000000000000000" +
+        "01";
+
+      const txdata = abiCoder.encode(
+        ["address[][]", "bytes[][]", "bool[]"],
+        [
+          [
+            [ethers.constants.AddressZero], // SetupGnosis + Deploy Guard
+          ],
+          [[badData]],
+          [true],
+        ]
+      );
+      bytecode = abiCoder.encode(["bytes", "bytes"], [txdata, sigs]);
+      await expect(
+        gnosisFactory.createProxyWithCallback(
+          gnosisSingletonAddress,
+          bytecode,
+          saltNum,
+          callback.address
+        )
+      ).to.be.revertedWith("CB000");
+    });
+  });
+});

--- a/test/Fractal-Module.ts
+++ b/test/Fractal-Module.ts
@@ -207,35 +207,17 @@ describe("Fractal-Module", () => {
       expect(await fractalModule.controllers(owner3.address)).eq(false);
     });
 
-    // it("Setup Guard w/ changeGuard event", async () => {
-    //   await expect(
-    //     gnosisFactory.createProxyWithCallback(
-    //       gnosisSingletonAddress,
-    //       bytecode,
-    //       saltNum,
-    //       callback.address
-    //     )
-    //   )
-    //     .to.emit(gnosisSafe, "ChangedGuard")
-    //     .withArgs(vetoGuard.address);
-    // });
-
-    // it("Setup Gnosis Safe w/ removedOwner event", async () => {
-    //   await expect(
-    //     gnosisFactory.createProxyWithCallback(
-    //       gnosisSingletonAddress,
-    //       bytecode,
-    //       saltNum,
-    //       callback.address
-    //     )
-    //   )
-    //     .to.emit(gnosisSafe, "RemovedOwner")
-    //     .withArgs(callback.address);
-    //   expect(await gnosisSafe.isOwner(owner1.address)).eq(true);
-    //   expect(await gnosisSafe.isOwner(owner2.address)).eq(true);
-    //   expect(await gnosisSafe.isOwner(owner3.address)).eq(true);
-    //   expect(await gnosisSafe.isOwner(callback.address)).eq(false);
-    //   expect(await gnosisSafe.getThreshold()).eq(threshold);
-    // });
+    it.only("Setup Module w/ enabledModule event", async () => {
+      await expect(
+        gnosisFactory.createProxyWithCallback(
+          gnosisSingletonAddress,
+          bytecode,
+          saltNum,
+          callback.address
+        )
+      )
+        .to.emit(gnosisSafe, "EnabledModule")
+        .withArgs(fractalModule.address);
+    });
   });
 });

--- a/test/Fractal-Module.ts
+++ b/test/Fractal-Module.ts
@@ -2,12 +2,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import { expect } from "chai";
 import { BigNumber, Contract } from "ethers";
 import { ethers, network } from "hardhat";
-import {
-  FractalModule,
-  VetoGuard,
-  VetoGuard__factory,
-  VotesToken__factory,
-} from "../typechain-types";
+import { FractalModule, VotesToken__factory } from "../typechain-types";
 import { CallbackGnosis } from "../typechain-types/contracts/CallbackGnosis";
 import { CallbackGnosis__factory } from "../typechain-types/factories/contracts/CallbackGnosis__factory";
 import { FractalModule__factory } from "../typechain-types/factories/contracts/FractalModule__factory";
@@ -31,9 +26,6 @@ describe("Fractal-Module", () => {
   let moduleFactory: Contract;
   let moduleImpl: FractalModule;
   let fractalModule: FractalModule;
-
-  let vetoGuard: VetoGuard;
-  let vetoImpl: VetoGuard;
   let callback: CallbackGnosis;
 
   // Wallets
@@ -42,12 +34,17 @@ describe("Fractal-Module", () => {
   let owner2: SignerWithAddress;
   let owner3: SignerWithAddress;
 
+  // Predicted Contracts
   let predictedFractalModule: string;
-  const abiCoder = new ethers.utils.AbiCoder(); // encode data
+
+  // Encode Data
+  const abiCoder = new ethers.utils.AbiCoder();
+
+  // Reused Vars
+  let bytecode: string;
   const gnosisFactoryAddress = "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2";
   const gnosisSingletonAddress = "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552";
   const threshold = 2;
-  let bytecode: string;
   const saltNum = BigNumber.from(
     "0x856d90216588f9ffc124d1480a440e1c012c7a816952bc968d737bae5d4e139c"
   );
@@ -189,7 +186,7 @@ describe("Fractal-Module", () => {
     );
   });
 
-  describe.only("Fractal Module Testing", () => {
+  describe("Fractal Module Testing", () => {
     it("Setup Fractal Module w/ ModuleProxyCreationEvent", async () => {
       await expect(
         gnosisFactory.createProxyWithCallback(

--- a/test/Fractal-Module.ts
+++ b/test/Fractal-Module.ts
@@ -80,7 +80,19 @@ describe("Fractal-Module", () => {
 
     callback = await new CallbackGnosis__factory(deployer).deploy(); // Gnosis Callback
 
-    // DEPLOY GUARD
+    // Setup GNOSIS
+    const createGnosisCalldata = ifaceSafe.encodeFunctionData("setup", [
+      [owner1.address, owner2.address, owner3.address, callback.address],
+      1,
+      ethers.constants.AddressZero,
+      ethers.constants.HashZero,
+      ethers.constants.AddressZero,
+      ethers.constants.AddressZero,
+      0,
+      ethers.constants.AddressZero,
+    ]);
+
+    // DEPLOY Module
     moduleImpl = await new FractalModule__factory(deployer).deploy();
     const fractalModuleInit =
       // eslint-disable-next-line camelcase
@@ -104,22 +116,20 @@ describe("Fractal-Module", () => {
       "10031021",
     ]);
 
-    // SET GUARD
-    // const setGuardCalldata = ifaceSafe.encodeFunctionData("setGuard", [
-    //   predictedVetoGuard,
-    // ]);
-
-    // Setup GNOSIS
-    const createGnosisCalldata = ifaceSafe.encodeFunctionData("setup", [
-      [owner1.address, owner2.address, owner3.address, callback.address],
-      1,
-      ethers.constants.AddressZero,
-      ethers.constants.HashZero,
-      ethers.constants.AddressZero,
-      ethers.constants.AddressZero,
-      0,
-      ethers.constants.AddressZero,
-    ]);
+    // SETUP Module
+    const setModuleCalldata =
+      // eslint-disable-next-line camelcase
+      FractalModule__factory.createInterface().encodeFunctionData("setUp", [
+        abiCoder.encode(
+          ["address", "address", "address", "address[]"],
+          [
+            owner1.address,
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+            [owner2.address],
+          ]
+        ),
+      ]);
 
     // REMOVE OWNER
     const removeCalldata = ifaceSafe.encodeFunctionData("removeOwner", [

--- a/test/Fractal-Module.ts
+++ b/test/Fractal-Module.ts
@@ -207,7 +207,7 @@ describe("Fractal-Module", () => {
       expect(await fractalModule.controllers(owner3.address)).eq(false);
     });
 
-    it.only("Setup Module w/ enabledModule event", async () => {
+    it("Setup Module w/ enabledModule event", async () => {
       await expect(
         gnosisFactory.createProxyWithCallback(
           gnosisSingletonAddress,
@@ -218,6 +218,34 @@ describe("Fractal-Module", () => {
       )
         .to.emit(gnosisSafe, "EnabledModule")
         .withArgs(fractalModule.address);
+    });
+
+    it.only("Owner may add/remove controllers", async () => {
+      await gnosisFactory.createProxyWithCallback(
+        gnosisSingletonAddress,
+        bytecode,
+        saltNum,
+        callback.address
+      );
+      // ADD Controller
+      await expect(
+        fractalModule.connect(owner3).addControllers([owner3.address])
+      ).to.revertedWith("Ownable: caller is not the owner");
+      expect(await fractalModule.controllers(owner3.address)).eq(false);
+      await expect(
+        fractalModule.connect(owner1).addControllers([owner3.address])
+      ).to.emit(fractalModule, "ControllersAdded");
+      expect(await fractalModule.controllers(owner3.address)).eq(true);
+
+      // REMOVE Controller
+      await expect(
+        fractalModule.connect(owner3).removeControllers([owner3.address])
+      ).to.revertedWith("Ownable: caller is not the owner");
+      expect(await fractalModule.controllers(owner3.address)).eq(true);
+      await expect(
+        fractalModule.connect(owner1).removeControllers([owner3.address])
+      ).to.emit(fractalModule, "ControllersRemoved");
+      expect(await fractalModule.controllers(owner3.address)).eq(false);
     });
   });
 });

--- a/test/Fractal-Module.ts
+++ b/test/Fractal-Module.ts
@@ -111,7 +111,7 @@ describe("Fractal-Module", () => {
     );
 
     const moduleData = ifaceFactory.encodeFunctionData("deployModule", [
-      vetoImpl.address,
+      moduleImpl.address,
       fractalModuleInit,
       "10031021",
     ]);
@@ -131,21 +131,16 @@ describe("Fractal-Module", () => {
         ),
       ]);
 
+    // ADD Module To Safe
+    const enableModuleCalldata = ifaceSafe.encodeFunctionData("enableModule", [
+      fractalModule.address,
+    ]);
+
     // REMOVE OWNER
     const removeCalldata = ifaceSafe.encodeFunctionData("removeOwner", [
       owner3.address,
       callback.address,
       threshold,
-    ]);
-
-    // INIT GUARD
-    const initParams = abiCoder.encode(
-      ["uint256", "address", "address", "address"],
-      [10, owner1.address, owner1.address, ethers.constants.AddressZero]
-    );
-
-    const initGuard = vetoGuard.interface.encodeFunctionData("setUp", [
-      initParams,
     ]);
 
     // TX Array
@@ -161,14 +156,14 @@ describe("Fractal-Module", () => {
         [
           [ethers.constants.AddressZero, moduleFactory.address], // SetupGnosis + Deploy Guard
           [
-            ethers.constants.AddressZero, // setGuard Gnosis
+            ethers.constants.AddressZero, // setup Module
+            ethers.constants.AddressZero, // enable Module GS
             ethers.constants.AddressZero, // remove owner + threshold
-            vetoGuard.address, // setup Guard
           ],
         ],
         [
           [createGnosisCalldata, moduleData],
-          [setGuardCalldata, removeCalldata, initGuard],
+          [setModuleCalldata, enableModuleCalldata, removeCalldata],
         ],
         [false, true],
       ]

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -179,6 +179,8 @@ export const abiSafe = [
   "event RemovedOwner(address owner)",
   "event SafeSetup(address indexed initiator, address[] owners, uint256 threshold, address initializer, address fallbackHandler)",
   "event EnabledModule(address module)",
+  "event ExecutionFromModuleSuccess(address indexed module)",
+  "event ExecutionFromModuleFailure(address indexed module)",
   "function getOwners() public view returns (address[] memory)",
   "function nonce() public view returns (uint256)",
   "function isOwner(address owner) public view returns (bool)",

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -155,6 +155,7 @@ export const ifaceSafe = new Interface([
   "function changeThreshold(uint256 _threshold) external",
   "function removeOwner(address prevOwner,address owner,uint256 _threshold) external",
   "function isOwner(address owner) public view returns (bool)",
+  "function enableModule(address module) public",
 ]);
 
 export const ifaceFactory = new Interface([
@@ -177,6 +178,7 @@ export const abiSafe = [
   "event ChangedGuard(address guard)",
   "event RemovedOwner(address owner)",
   "event SafeSetup(address indexed initiator, address[] owners, uint256 threshold, address initializer, address fallbackHandler)",
+  "event EnabledModule(address module)",
   "function getOwners() public view returns (address[] memory)",
   "function nonce() public view returns (uint256)",
   "function isOwner(address owner) public view returns (bool)",


### PR DESCRIPTION
Description
This PR adds the Fractal Module to the codebase,

The Fractal Module is setup by the gnosis safe and is used by the Parent DAO to update state vars or to execute txs onbehalf of the GS signer set. Therefore; this module may peform any arb tx on the gnosis safe including the clawback of funds.

The signer set may place a tx to disable this module; however, it must go through the queue / veto process controlled by the parent DAO.

One thing to note is the addition of controllers which may act on behalf of the parentDAO(owner) of the Fractal Module. The only methods it may not call are the add and remove controller functions.

Notes
There is no need to maintain our own factory instance in order to read events to see if a contract is a fractal gnosis safe. We may use the ModuleProxyFactory.sol created by Zodic and query the events to see if a safe utilized our fractal impl address. 

event ModuleProxyCreation(
        address indexed proxy,
        address indexed masterCopy
    );

Issue (if applicable)

Testing
Once the branch has been pulled down locally, run:
npm install
npx hardhat test

Screenshots (if applicable)